### PR TITLE
Fix default operation ID

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 //  AGENTS.md
 //  feather-openapi
 //
-//  Created by Binary Birds on 2026. 01. 20..
+//  Created by Binary Birds on 2026. 01. 20.
 
 # Repository Guidelines
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 The FeatherOpenAPI library makes it easy to define OpenAPI specifications using Swift in a type-safe way.
 
-[![Release: 1.0.0-beta.6](https://img.shields.io/badge/Release-1%2E0%2E0--beta%2E6-F05138)](https://github.com/feather-framework/feather-openapi/releases/tag/1.0.0-beta.6)
+[
+    ![Release: 1.0.0-beta.7](https://img.shields.io/badge/Release-1%2E0%2E0--beta%2E7-F05138)
+](
+    https://github.com/feather-framework/feather-openapi/releases/tag/1.0.0-beta.7
+)
 
 ## Features
 
@@ -30,7 +34,7 @@ The FeatherOpenAPI library makes it easy to define OpenAPI specifications using 
 Use Swift Package Manager; add the dependency to your `Package.swift` file:
 
 ```swift
-.package(url: "https://github.com/feather-framework/feather-openapi", exact: "1.0.0-beta.6"),
+.package(url: "https://github.com/feather-framework/feather-openapi", exact: "1.0.0-beta.7"),
 ```
 
 Then add `FeatherOpenAPI` to your target dependencies:
@@ -41,7 +45,11 @@ Then add `FeatherOpenAPI` to your target dependencies:
 
 ## Usage
 
-[![DocC API documentation](https://img.shields.io/badge/DocC-API_documentation-F05138)](https://feather-framework.github.io/feather-openapi/)
+[
+    ![DocC API documentation](https://img.shields.io/badge/DocC-API_documentation-F05138)
+](
+    https://feather-framework.github.io/feather-openapi/
+)
 
 API documentation is available at the following link.
 

--- a/Sources/FeatherOpenAPI/Callback/CallbackID.swift
+++ b/Sources/FeatherOpenAPI/Callback/CallbackID.swift
@@ -2,7 +2,7 @@
 //  CallbackID.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 public struct CallbackID: Sendable, Equatable, Hashable, Codable {

--- a/Sources/FeatherOpenAPI/Components/Components.swift
+++ b/Sources/FeatherOpenAPI/Components/Components.swift
@@ -2,7 +2,7 @@
 //  Components.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Components/ComponentsRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Components/ComponentsRepresentable.swift
@@ -2,7 +2,7 @@
 //  ComponentsRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 21..
+//  Created by Tibor Bödecs on 2026. 01. 21.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Components/OpenAPIComponentsRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Components/OpenAPIComponentsRepresentable.swift
@@ -2,7 +2,7 @@
 //  OpenAPIComponentsRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Contact/ContactRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Contact/ContactRepresentable.swift
@@ -2,7 +2,7 @@
 //  ContactRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 21..
+//  Created by Tibor Bödecs on 2026. 01. 21.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Contact/OpenAPIContactRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Contact/OpenAPIContactRepresentable.swift
@@ -2,7 +2,7 @@
 //  OpenAPIContactRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Content/Content.swift
+++ b/Sources/FeatherOpenAPI/Content/Content.swift
@@ -2,7 +2,7 @@
 //  Content.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Content/ContentMap.swift
+++ b/Sources/FeatherOpenAPI/Content/ContentMap.swift
@@ -2,7 +2,7 @@
 //  ContentMap.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Content/ContentRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Content/ContentRepresentable.swift
@@ -2,7 +2,7 @@
 //  ContentRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Content/OpenAPIContentRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Content/OpenAPIContentRepresentable.swift
@@ -2,7 +2,7 @@
 //  OpenAPIContentRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 21..
+//  Created by Tibor Bödecs on 2026. 01. 21.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Document/DocumentRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Document/DocumentRepresentable.swift
@@ -2,7 +2,7 @@
 //  DocumentRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 21..
+//  Created by Tibor Bödecs on 2026. 01. 21.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Document/OpenAPIDocumentRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Document/OpenAPIDocumentRepresentable.swift
@@ -2,7 +2,7 @@
 //  OpenAPIDocumentRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Example/ExampleID.swift
+++ b/Sources/FeatherOpenAPI/Example/ExampleID.swift
@@ -2,7 +2,7 @@
 //  ExampleID.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 public struct ExampleID: Sendable, Equatable, Hashable, Codable {

--- a/Sources/FeatherOpenAPI/Example/ExampleRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Example/ExampleRepresentable.swift
@@ -2,7 +2,7 @@
 //  ExampleRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 21..
+//  Created by Tibor Bödecs on 2026. 01. 21.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Example/OpenAPIExampleRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Example/OpenAPIExampleRepresentable.swift
@@ -2,7 +2,7 @@
 //  OpenAPIExampleRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/ExternalDocs/ExternalDocsRepresentable.swift
+++ b/Sources/FeatherOpenAPI/ExternalDocs/ExternalDocsRepresentable.swift
@@ -2,7 +2,7 @@
 //  ExternalDocsRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 21..
+//  Created by Tibor Bödecs on 2026. 01. 21.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/ExternalDocs/OpenAPIExternalDocsRepresentable.swift
+++ b/Sources/FeatherOpenAPI/ExternalDocs/OpenAPIExternalDocsRepresentable.swift
@@ -2,7 +2,7 @@
 //  OpenAPIExternalDocsRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Header/HeaderID.swift
+++ b/Sources/FeatherOpenAPI/Header/HeaderID.swift
@@ -2,7 +2,7 @@
 //  HeaderID.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 public struct HeaderID: Sendable, Equatable, Hashable, Codable {

--- a/Sources/FeatherOpenAPI/Header/HeaderMap.swift
+++ b/Sources/FeatherOpenAPI/Header/HeaderMap.swift
@@ -2,7 +2,7 @@
 //  HeaderMap.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Header/HeaderRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Header/HeaderRepresentable.swift
@@ -2,7 +2,7 @@
 //  HeaderRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 21..
+//  Created by Tibor Bödecs on 2026. 01. 21.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Header/OpenAPIHeaderRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Header/OpenAPIHeaderRepresentable.swift
@@ -2,7 +2,7 @@
 //  OpenAPIHeaderRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Identifiable.swift
+++ b/Sources/FeatherOpenAPI/Identifiable.swift
@@ -2,7 +2,7 @@
 //  Identifiable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 public protocol Identifiable: Sendable {

--- a/Sources/FeatherOpenAPI/Info/InfoRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Info/InfoRepresentable.swift
@@ -2,7 +2,7 @@
 //  InfoRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Info/OpenAPIInfoRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Info/OpenAPIInfoRepresentable.swift
@@ -2,7 +2,7 @@
 //  OpenAPIInfoRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 21..
+//  Created by Tibor Bödecs on 2026. 01. 21.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/License/LicenseRepresentable.swift
+++ b/Sources/FeatherOpenAPI/License/LicenseRepresentable.swift
@@ -2,7 +2,7 @@
 //  LicenseRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 21..
+//  Created by Tibor Bödecs on 2026. 01. 21.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/License/OpenAPILicenseRepresentable.swift
+++ b/Sources/FeatherOpenAPI/License/OpenAPILicenseRepresentable.swift
@@ -2,7 +2,7 @@
 //  OpenAPILicenseRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Link/LinkID.swift
+++ b/Sources/FeatherOpenAPI/Link/LinkID.swift
@@ -2,7 +2,7 @@
 //  LinkID.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 public struct LinkID: Sendable, Equatable, Hashable, Codable {

--- a/Sources/FeatherOpenAPI/Link/OpenAPILinkRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Link/OpenAPILinkRepresentable.swift
@@ -2,7 +2,7 @@
 //  OpenAPILinkRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Location/LocationRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Location/LocationRepresentable.swift
@@ -2,7 +2,7 @@
 //  LocationRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 21..
+//  Created by Tibor Bödecs on 2026. 01. 21.
 //
 
 #if canImport(FoundationEssentials)

--- a/Sources/FeatherOpenAPI/Location/OpenAPILocationRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Location/OpenAPILocationRepresentable.swift
@@ -2,7 +2,7 @@
 //  OpenAPILocationRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 #if canImport(FoundationEssentials)

--- a/Sources/FeatherOpenAPI/Operation/OpenAPIOperationRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Operation/OpenAPIOperationRepresentable.swift
@@ -2,7 +2,7 @@
 //  OpenAPIOperationRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Operation/OperationRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Operation/OperationRepresentable.swift
@@ -2,7 +2,7 @@
 //  OperationRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 21..
+//  Created by Tibor Bödecs on 2026. 01. 21.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Operation/OperationRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Operation/OperationRepresentable.swift
@@ -62,24 +62,27 @@ extension OperationRepresentable {
     /// Default summary is `nil`.
     public var summary: String? { nil }
 
-    /// Default operation identifier is `nil`.
-    public var operationId: String? { nil }
+    /// Computes a default operation identifier from the type name.
+    public var operationId: String? {
+        let suffix = "Operation"
+        let operationTypeName = String(reflecting: type(of: self))
+            .split(separator: ".")
+            .filter { $0.hasSuffix(suffix) }
+            .map(String.init)
+            .joined(separator: "")
+        guard !operationTypeName.isEmpty else {
+            return nil
+        }
+
+        let typeName = operationTypeName.dropLast(suffix.count)
+        guard !typeName.isEmpty else {
+            return nil
+        }
+
+        return String(typeName).lowercasedFirstLetter()
+    }
     /// Default parameters are empty.
     public var parameters: [ParameterRepresentable] { [] }
-
-    /// Computes a default operation identifier from the type name.
-    public static var operationId: String {
-        var components = String(reflecting: self)
-            .split(separator: ".")
-            .dropFirst()
-            .map(String.init)
-
-        components.remove(at: 2)
-        if let last = components.popLast()?.lowercasedFirstLetter() {
-            components.insert(last, at: 0)
-        }
-        return components.joined(separator: "")
-    }
 
     /// Default request body is `nil`.
     public var requestBody: RequestBodyRepresentable? { nil }

--- a/Sources/FeatherOpenAPI/OrderedDictionary+Merge.swift
+++ b/Sources/FeatherOpenAPI/OrderedDictionary+Merge.swift
@@ -2,7 +2,7 @@
 //  OrderedDictionary+Merge.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 25..
+//  Created by Tibor Bödecs on 2026. 01. 25.
 
 import OpenAPIKit30
 

--- a/Sources/FeatherOpenAPI/Parameter/Abstraction/OpenAPIParameterRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Parameter/Abstraction/OpenAPIParameterRepresentable.swift
@@ -2,7 +2,7 @@
 //  OpenAPIParameterRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Parameter/Abstraction/ParameterID.swift
+++ b/Sources/FeatherOpenAPI/Parameter/Abstraction/ParameterID.swift
@@ -2,7 +2,7 @@
 //  ParameterID.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 public struct ParameterID: Sendable, Equatable, Hashable, Codable {

--- a/Sources/FeatherOpenAPI/Parameter/Abstraction/ParameterRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Parameter/Abstraction/ParameterRepresentable.swift
@@ -2,7 +2,7 @@
 //  ParameterRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 21..
+//  Created by Tibor Bödecs on 2026. 01. 21.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Parameter/CookieParameterRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Parameter/CookieParameterRepresentable.swift
@@ -2,7 +2,7 @@
 //  CookieParameterRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Parameter/HeaderParameterRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Parameter/HeaderParameterRepresentable.swift
@@ -2,7 +2,7 @@
 //  HeaderParameterRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Parameter/PathParameterRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Parameter/PathParameterRepresentable.swift
@@ -2,7 +2,7 @@
 //  PathParameterRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Parameter/QueryParameterRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Parameter/QueryParameterRepresentable.swift
@@ -2,7 +2,7 @@
 //  QueryParameterRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Path.swift
+++ b/Sources/FeatherOpenAPI/Path.swift
@@ -2,7 +2,7 @@
 //  Path.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 25..
+//  Created by Tibor Bödecs on 2026. 01. 25.
 
 /// A lightweight OpenAPI path wrapper with composition helpers.
 public struct Path: ExpressibleByStringLiteral {

--- a/Sources/FeatherOpenAPI/PathCollection/PathCollectionRepresentable.swift
+++ b/Sources/FeatherOpenAPI/PathCollection/PathCollectionRepresentable.swift
@@ -2,7 +2,7 @@
 //  PathCollectionRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/PathItem/OpenAPIPathItemRepresentable.swift
+++ b/Sources/FeatherOpenAPI/PathItem/OpenAPIPathItemRepresentable.swift
@@ -2,7 +2,7 @@
 //  OpenAPIPathItemRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/PathItem/PathItemRepresentable.swift
+++ b/Sources/FeatherOpenAPI/PathItem/PathItemRepresentable.swift
@@ -2,7 +2,7 @@
 //  PathItemRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 21..
+//  Created by Tibor Bödecs on 2026. 01. 21.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/PathItem/PathMap.swift
+++ b/Sources/FeatherOpenAPI/PathItem/PathMap.swift
@@ -2,7 +2,7 @@
 //  PathMap.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Reference/ExampleReferenceRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Reference/ExampleReferenceRepresentable.swift
@@ -2,7 +2,7 @@
 //  ExampleReferenceRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 24..
+//  Created by Tibor Bödecs on 2026. 01. 24.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Reference/HeaderReferenceRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Reference/HeaderReferenceRepresentable.swift
@@ -2,7 +2,7 @@
 //  HeaderReferenceRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Reference/ParameterReferenceRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Reference/ParameterReferenceRepresentable.swift
@@ -2,7 +2,7 @@
 //  ParameterReferenceRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Reference/ReferencedSchemaMapRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Reference/ReferencedSchemaMapRepresentable.swift
@@ -2,7 +2,7 @@
 //  ReferencedSchemaMapRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Reference/RequestBodyReferenceRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Reference/RequestBodyReferenceRepresentable.swift
@@ -2,7 +2,7 @@
 //  RequestBodyReferenceRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Reference/ResponseReferenceRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Reference/ResponseReferenceRepresentable.swift
@@ -2,7 +2,7 @@
 //  ResponseReferenceRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Reference/SchemaReference.swift
+++ b/Sources/FeatherOpenAPI/Reference/SchemaReference.swift
@@ -2,7 +2,7 @@
 //  SchemaReference.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/RequestBody/Abstraction/OpenAPIRequestBodyRepresentable.swift
+++ b/Sources/FeatherOpenAPI/RequestBody/Abstraction/OpenAPIRequestBodyRepresentable.swift
@@ -2,7 +2,7 @@
 //  OpenAPIRequestBodyRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 21..
+//  Created by Tibor Bödecs on 2026. 01. 21.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/RequestBody/Abstraction/RequestBodyID.swift
+++ b/Sources/FeatherOpenAPI/RequestBody/Abstraction/RequestBodyID.swift
@@ -2,7 +2,7 @@
 //  RequestBodyID.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 public struct RequestBodyID: Sendable, Equatable, Hashable, Codable {

--- a/Sources/FeatherOpenAPI/RequestBody/Abstraction/RequestBodyRepresentable.swift
+++ b/Sources/FeatherOpenAPI/RequestBody/Abstraction/RequestBodyRepresentable.swift
@@ -2,7 +2,7 @@
 //  RequestBodyRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/RequestBody/BinaryRequestBodyRepresentable.swift
+++ b/Sources/FeatherOpenAPI/RequestBody/BinaryRequestBodyRepresentable.swift
@@ -2,7 +2,7 @@
 //  BinaryRequestBodyRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/RequestBody/FormRequestBodyRepresentable.swift
+++ b/Sources/FeatherOpenAPI/RequestBody/FormRequestBodyRepresentable.swift
@@ -2,7 +2,7 @@
 //  FormRequestBodyRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/RequestBody/JSONRequestBodyRepresentable.swift
+++ b/Sources/FeatherOpenAPI/RequestBody/JSONRequestBodyRepresentable.swift
@@ -2,7 +2,7 @@
 //  JSONRequestBodyRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Response/Abstraction/OpenAPIResponseRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Response/Abstraction/OpenAPIResponseRepresentable.swift
@@ -2,7 +2,7 @@
 //  OpenAPIResponseRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Response/Abstraction/ResponseID.swift
+++ b/Sources/FeatherOpenAPI/Response/Abstraction/ResponseID.swift
@@ -2,7 +2,7 @@
 //  ResponseID.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 public struct ResponseID: Sendable, Equatable, Hashable, Codable {

--- a/Sources/FeatherOpenAPI/Response/Abstraction/ResponseMap.swift
+++ b/Sources/FeatherOpenAPI/Response/Abstraction/ResponseMap.swift
@@ -2,7 +2,7 @@
 //  ResponseMap.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Response/Abstraction/ResponseRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Response/Abstraction/ResponseRepresentable.swift
@@ -2,7 +2,7 @@
 //  ResponseRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 21..
+//  Created by Tibor Bödecs on 2026. 01. 21.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Response/Abstraction/ResponseRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Response/Abstraction/ResponseRepresentable.swift
@@ -37,10 +37,13 @@ extension ResponseRepresentable {
     public func openAPIResponse() -> Either<
         JSONReference<OpenAPI.Response>, OpenAPI.Response
     > {
-        .init(
+        let responseHeaders: OpenAPI.Header.Map? =
+            headerMap.isEmpty ? nil : headerMap.mapValues { $0.openAPIHeader() }
+
+        return .init(
             .init(
                 description: description,
-                headers: headerMap.mapValues { $0.openAPIHeader() },
+                headers: responseHeaders,
                 content: contentMap.mapValues { $0.openAPIContent() },
                 links: [:],
                 vendorExtensions: vendorExtensions

--- a/Sources/FeatherOpenAPI/Response/BinaryResponseRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Response/BinaryResponseRepresentable.swift
@@ -2,7 +2,7 @@
 //  BinaryResponseRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Response/FormResponseRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Response/FormResponseRepresentable.swift
@@ -2,7 +2,7 @@
 //  FormResponseRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Response/JSONResponseRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Response/JSONResponseRepresentable.swift
@@ -2,7 +2,7 @@
 //  JSONResponseRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Schema/Abstraction/OpenAPISchemaRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Schema/Abstraction/OpenAPISchemaRepresentable.swift
@@ -2,7 +2,7 @@
 //  OpenAPISchemaRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 21..
+//  Created by Tibor Bödecs on 2026. 01. 21.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Schema/Abstraction/SchemaID.swift
+++ b/Sources/FeatherOpenAPI/Schema/Abstraction/SchemaID.swift
@@ -2,7 +2,7 @@
 //  SchemaID.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 public struct SchemaID: Sendable, Equatable, Hashable, Codable {

--- a/Sources/FeatherOpenAPI/Schema/Abstraction/SchemaMap.swift
+++ b/Sources/FeatherOpenAPI/Schema/Abstraction/SchemaMap.swift
@@ -2,7 +2,7 @@
 //  SchemaMap.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Schema/Abstraction/SchemaRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Schema/Abstraction/SchemaRepresentable.swift
@@ -2,7 +2,7 @@
 //  SchemaRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Schema/ArraySchemaRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Schema/ArraySchemaRepresentable.swift
@@ -2,7 +2,7 @@
 //  ArraySchemaRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Schema/BinarySchema.swift
+++ b/Sources/FeatherOpenAPI/Schema/BinarySchema.swift
@@ -2,7 +2,7 @@
 //  BinarySchema.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 24..
+//  Created by Tibor Bödecs on 2026. 01. 24.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Schema/BoolSchemaRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Schema/BoolSchemaRepresentable.swift
@@ -2,7 +2,7 @@
 //  BoolSchemaRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Schema/DoubleSchemaRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Schema/DoubleSchemaRepresentable.swift
@@ -2,7 +2,7 @@
 //  DoubleSchemaRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Schema/FloatSchemaRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Schema/FloatSchemaRepresentable.swift
@@ -2,7 +2,7 @@
 //  FloatSchemaRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Schema/Int32SchemaRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Schema/Int32SchemaRepresentable.swift
@@ -2,7 +2,7 @@
 //  Int32SchemaRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Schema/Int64SchemaRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Schema/Int64SchemaRepresentable.swift
@@ -2,7 +2,7 @@
 //  Int64SchemaRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Schema/IntSchemaRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Schema/IntSchemaRepresentable.swift
@@ -2,7 +2,7 @@
 //  IntSchemaRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Schema/ObjectSchemaRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Schema/ObjectSchemaRepresentable.swift
@@ -2,7 +2,7 @@
 //  ObjectSchemaRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Schema/StringSchemaRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Schema/StringSchemaRepresentable.swift
@@ -2,7 +2,7 @@
 //  StringSchemaRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/SecurityRequirement/OpenAPISecurityRequirementRepresentable.swift
+++ b/Sources/FeatherOpenAPI/SecurityRequirement/OpenAPISecurityRequirementRepresentable.swift
@@ -2,7 +2,7 @@
 //  OpenAPISecurityRequirementRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/SecurityRequirement/SecurityRequirementRepresentable.swift
+++ b/Sources/FeatherOpenAPI/SecurityRequirement/SecurityRequirementRepresentable.swift
@@ -2,7 +2,7 @@
 //  SecurityRequirementRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 21..
+//  Created by Tibor Bödecs on 2026. 01. 21.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/SecurityScheme/OpenAPISecuritySchemeRepresentable.swift
+++ b/Sources/FeatherOpenAPI/SecurityScheme/OpenAPISecuritySchemeRepresentable.swift
@@ -2,7 +2,7 @@
 //  OpenAPISecuritySchemeRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/SecurityScheme/SecuritySchemeRepresentable.swift
+++ b/Sources/FeatherOpenAPI/SecurityScheme/SecuritySchemeRepresentable.swift
@@ -2,7 +2,7 @@
 //  SecuritySchemeRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 21..
+//  Created by Tibor Bödecs on 2026. 01. 21.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Server/OpenAPIServerRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Server/OpenAPIServerRepresentable.swift
@@ -2,7 +2,7 @@
 //  OpenAPIServerRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Server/ServerRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Server/ServerRepresentable.swift
@@ -2,7 +2,7 @@
 //  ServerRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 21..
+//  Created by Tibor Bödecs on 2026. 01. 21.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Tag/OpenAPITagRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Tag/OpenAPITagRepresentable.swift
@@ -2,7 +2,7 @@
 //  OpenAPITagRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 21..
+//  Created by Tibor Bödecs on 2026. 01. 21.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Tag/TagRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Tag/TagRepresentable.swift
@@ -2,7 +2,7 @@
 //  TagRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Variable/OpenAPIVariableRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Variable/OpenAPIVariableRepresentable.swift
@@ -2,7 +2,7 @@
 //  OpenAPIVariableRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Variable/VariableMap.swift
+++ b/Sources/FeatherOpenAPI/Variable/VariableMap.swift
@@ -2,7 +2,7 @@
 //  VariableMap.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/Variable/VariableRepresentable.swift
+++ b/Sources/FeatherOpenAPI/Variable/VariableRepresentable.swift
@@ -2,7 +2,7 @@
 //  VariableRepresentable.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 21..
+//  Created by Tibor Bödecs on 2026. 01. 21.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/_Properties/AllowedValuesProperty.swift
+++ b/Sources/FeatherOpenAPI/_Properties/AllowedValuesProperty.swift
@@ -2,7 +2,7 @@
 //  AllowedValuesProperty.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/_Properties/DefaultValueProperty.swift
+++ b/Sources/FeatherOpenAPI/_Properties/DefaultValueProperty.swift
@@ -2,7 +2,7 @@
 //  DefaultValueProperty.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/_Properties/DeprecatedProperty.swift
+++ b/Sources/FeatherOpenAPI/_Properties/DeprecatedProperty.swift
@@ -2,7 +2,7 @@
 //  DeprecatedProperty.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 public protocol DeprecatedProperty {

--- a/Sources/FeatherOpenAPI/_Properties/DescriptionProperty.swift
+++ b/Sources/FeatherOpenAPI/_Properties/DescriptionProperty.swift
@@ -2,7 +2,7 @@
 //  DescriptionProperty.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 public protocol DescriptionProperty {

--- a/Sources/FeatherOpenAPI/_Properties/ExampleProperty.swift
+++ b/Sources/FeatherOpenAPI/_Properties/ExampleProperty.swift
@@ -2,7 +2,7 @@
 //  ExampleProperty.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import OpenAPIKit30

--- a/Sources/FeatherOpenAPI/_Properties/NullableProperty.swift
+++ b/Sources/FeatherOpenAPI/_Properties/NullableProperty.swift
@@ -2,7 +2,7 @@
 //  NullableProperty.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 public protocol NullableProperty {

--- a/Sources/FeatherOpenAPI/_Properties/RequiredProperty.swift
+++ b/Sources/FeatherOpenAPI/_Properties/RequiredProperty.swift
@@ -2,7 +2,7 @@
 //  RequiredProperty.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 public protocol RequiredProperty {

--- a/Sources/FeatherOpenAPI/_Properties/TitleProperty.swift
+++ b/Sources/FeatherOpenAPI/_Properties/TitleProperty.swift
@@ -2,7 +2,7 @@
 //  TitleProperty.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 public protocol TitleProperty {

--- a/Sources/FeatherOpenAPI/_Properties/VendorExtensionsProperty.swift
+++ b/Sources/FeatherOpenAPI/_Properties/VendorExtensionsProperty.swift
@@ -2,7 +2,7 @@
 //  VendorExtensionsProperty.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 23..
+//  Created by Tibor Bödecs on 2026. 01. 23.
 //
 
 import OpenAPIKit30

--- a/Tests/FeatherOpenAPITests/Example/Components/Example.swift
+++ b/Tests/FeatherOpenAPITests/Example/Components/Example.swift
@@ -2,6 +2,6 @@
 //  Example.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 25..
+//  Created by Tibor Bödecs on 2026. 01. 25.
 
 enum Example {}

--- a/Tests/FeatherOpenAPITests/Example/Components/ExampleDocument.swift
+++ b/Tests/FeatherOpenAPITests/Example/Components/ExampleDocument.swift
@@ -2,7 +2,7 @@
 //  ExampleDocument.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 25..
+//  Created by Tibor Bödecs on 2026. 01. 25.
 
 import FeatherOpenAPI
 import OpenAPIKit30

--- a/Tests/FeatherOpenAPITests/Example/Components/ExampleDuplicatedItem.swift
+++ b/Tests/FeatherOpenAPITests/Example/Components/ExampleDuplicatedItem.swift
@@ -2,6 +2,6 @@
 //  ExampleDuplicatedItem.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 25..
+//  Created by Tibor Bödecs on 2026. 01. 25.
 
 enum ExampleDuplicatedItem {}

--- a/Tests/FeatherOpenAPITests/Example/Components/ExampleDuplicatedItemDocument.swift
+++ b/Tests/FeatherOpenAPITests/Example/Components/ExampleDuplicatedItemDocument.swift
@@ -2,7 +2,7 @@
 //  ExampleDuplicatedItemDocument.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 25..
+//  Created by Tibor Bödecs on 2026. 01. 25.
 
 import FeatherOpenAPI
 import OpenAPIKit30

--- a/Tests/FeatherOpenAPITests/Example/Components/ExampleDuplicatedItemModel+Schemas.swift
+++ b/Tests/FeatherOpenAPITests/Example/Components/ExampleDuplicatedItemModel+Schemas.swift
@@ -2,7 +2,7 @@
 //  ExampleDuplicatedItemModel+Schemas.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 25..
+//  Created by Tibor Bödecs on 2026. 01. 25.
 
 import FeatherOpenAPI
 

--- a/Tests/FeatherOpenAPITests/Example/Components/ExampleDuplicatedItemModel.swift
+++ b/Tests/FeatherOpenAPITests/Example/Components/ExampleDuplicatedItemModel.swift
@@ -2,7 +2,7 @@
 //  ExampleDuplicatedItemModel.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 25..
+//  Created by Tibor Bödecs on 2026. 01. 25.
 
 import FeatherOpenAPI
 

--- a/Tests/FeatherOpenAPITests/Example/Components/ExampleMissingParentItem.swift
+++ b/Tests/FeatherOpenAPITests/Example/Components/ExampleMissingParentItem.swift
@@ -2,6 +2,6 @@
 //  ExampleMissingParentItem.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 25..
+//  Created by Tibor Bödecs on 2026. 01. 25.
 
 enum ExampleMissingParentItem {}

--- a/Tests/FeatherOpenAPITests/Example/Components/ExampleMissingParentItemDocument.swift
+++ b/Tests/FeatherOpenAPITests/Example/Components/ExampleMissingParentItemDocument.swift
@@ -2,7 +2,7 @@
 //  ExampleMissingParentItemDocument.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 25..
+//  Created by Tibor Bödecs on 2026. 01. 25.
 
 import FeatherOpenAPI
 import OpenAPIKit30

--- a/Tests/FeatherOpenAPITests/Example/Components/ExampleMissingParentItemModel+Schemas.swift
+++ b/Tests/FeatherOpenAPITests/Example/Components/ExampleMissingParentItemModel+Schemas.swift
@@ -2,7 +2,7 @@
 //  ExampleMissingParentItemModel+Schemas.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 25..
+//  Created by Tibor Bödecs on 2026. 01. 25.
 
 import FeatherOpenAPI
 

--- a/Tests/FeatherOpenAPITests/Example/Components/ExampleMissingParentItemModel.swift
+++ b/Tests/FeatherOpenAPITests/Example/Components/ExampleMissingParentItemModel.swift
@@ -2,7 +2,7 @@
 //  ExampleMissingParentItemModel.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 25..
+//  Created by Tibor Bödecs on 2026. 01. 25.
 
 import FeatherOpenAPI
 

--- a/Tests/FeatherOpenAPITests/Example/Components/ExampleModel+Headers.swift
+++ b/Tests/FeatherOpenAPITests/Example/Components/ExampleModel+Headers.swift
@@ -2,7 +2,7 @@
 //  ExampleModel+Headers.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 25..
+//  Created by Tibor Bödecs on 2026. 01. 25.
 
 import FeatherOpenAPI
 

--- a/Tests/FeatherOpenAPITests/Example/Components/ExampleModel+Operations.swift
+++ b/Tests/FeatherOpenAPITests/Example/Components/ExampleModel+Operations.swift
@@ -2,7 +2,7 @@
 //  ExampleModel+Operations.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 25..
+//  Created by Tibor Bödecs on 2026. 01. 25.
 
 import FeatherOpenAPI
 import OpenAPIKit30

--- a/Tests/FeatherOpenAPITests/Example/Components/ExampleModel+Parameters.swift
+++ b/Tests/FeatherOpenAPITests/Example/Components/ExampleModel+Parameters.swift
@@ -2,7 +2,7 @@
 //  ExampleModel+Parameters.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 25..
+//  Created by Tibor Bödecs on 2026. 01. 25.
 
 import FeatherOpenAPI
 

--- a/Tests/FeatherOpenAPITests/Example/Components/ExampleModel+PathItems.swift
+++ b/Tests/FeatherOpenAPITests/Example/Components/ExampleModel+PathItems.swift
@@ -2,7 +2,7 @@
 //  ExampleModel+PathItems.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 25..
+//  Created by Tibor Bödecs on 2026. 01. 25.
 
 import FeatherOpenAPI
 

--- a/Tests/FeatherOpenAPITests/Example/Components/ExampleModel+RequestBodies.swift
+++ b/Tests/FeatherOpenAPITests/Example/Components/ExampleModel+RequestBodies.swift
@@ -2,7 +2,7 @@
 //  ExampleModel+RequestBodies.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 25..
+//  Created by Tibor Bödecs on 2026. 01. 25.
 
 import FeatherOpenAPI
 

--- a/Tests/FeatherOpenAPITests/Example/Components/ExampleModel+Responses.swift
+++ b/Tests/FeatherOpenAPITests/Example/Components/ExampleModel+Responses.swift
@@ -2,7 +2,7 @@
 //  ExampleModel+Responses.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 25..
+//  Created by Tibor Bödecs on 2026. 01. 25.
 
 import FeatherOpenAPI
 import OpenAPIKit30

--- a/Tests/FeatherOpenAPITests/Example/Components/ExampleModel+Schemas.swift
+++ b/Tests/FeatherOpenAPITests/Example/Components/ExampleModel+Schemas.swift
@@ -2,7 +2,7 @@
 //  ExampleModel+Schemas.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 25..
+//  Created by Tibor Bödecs on 2026. 01. 25.
 
 import FeatherOpenAPI
 import OpenAPIKit30

--- a/Tests/FeatherOpenAPITests/Example/Components/ExampleModel+SecuritySchemes.swift
+++ b/Tests/FeatherOpenAPITests/Example/Components/ExampleModel+SecuritySchemes.swift
@@ -2,7 +2,7 @@
 //  ExampleModel+SecuritySchemes.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 25..
+//  Created by Tibor Bödecs on 2026. 01. 25.
 
 import FeatherOpenAPI
 import OpenAPIKit30

--- a/Tests/FeatherOpenAPITests/Example/Components/ExampleModel+Tags.swift
+++ b/Tests/FeatherOpenAPITests/Example/Components/ExampleModel+Tags.swift
@@ -2,7 +2,7 @@
 //  ExampleModel+Tags.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 25..
+//  Created by Tibor Bödecs on 2026. 01. 25.
 
 import FeatherOpenAPI
 

--- a/Tests/FeatherOpenAPITests/Example/Components/ExampleModel.swift
+++ b/Tests/FeatherOpenAPITests/Example/Components/ExampleModel.swift
@@ -2,7 +2,7 @@
 //  ExampleModel.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 25..
+//  Created by Tibor Bödecs on 2026. 01. 25.
 
 import FeatherOpenAPI
 

--- a/Tests/FeatherOpenAPITests/Example/ExampleTestSuite.swift
+++ b/Tests/FeatherOpenAPITests/Example/ExampleTestSuite.swift
@@ -2,7 +2,7 @@
 //  ExampleTestSuite.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 25..
+//  Created by Tibor Bödecs on 2026. 01. 25.
 
 import OpenAPIKit
 import OpenAPIKit30

--- a/Tests/FeatherOpenAPITests/FeatherOpenAPITestSuite.swift
+++ b/Tests/FeatherOpenAPITests/FeatherOpenAPITestSuite.swift
@@ -2,7 +2,7 @@
 //  FeatherOpenAPITestSuite.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 02. 05..
+//  Created by Tibor Bödecs on 2026. 02. 05.
 //
 
 import OpenAPIKit

--- a/Tests/FeatherOpenAPITests/OperationRepresentableTestSuite.swift
+++ b/Tests/FeatherOpenAPITests/OperationRepresentableTestSuite.swift
@@ -1,0 +1,52 @@
+//
+//  OperationRepresentableTestSuite.swift
+//  feather-openapi
+//
+//  Created by Codex on 2026. 03. 24..
+//
+
+import OpenAPIKit30
+import Testing
+
+@testable import FeatherOpenAPI
+
+private enum OperationIdFixture {
+
+    struct ListPetsOperation: OperationRepresentable {
+        var responseMap: ResponseMap {
+            [.default: EmptyResponse()]
+        }
+    }
+
+    struct ListPets: OperationRepresentable {
+        var responseMap: ResponseMap {
+            [.default: EmptyResponse()]
+        }
+    }
+
+    struct EmptyResponse: ResponseRepresentable {
+        let description = "ok"
+        let openAPIIdentifier = "OperationIdFixtureEmptyResponse"
+        var contentMap: ContentMap { [:] }
+    }
+}
+
+
+@Suite
+struct OperationRepresentableTestSuite {
+
+    @Test
+    func defaultOperationIdUsesOperationTypeName() {
+        let operation = OperationIdFixture.ListPetsOperation()
+
+        #expect(operation.operationId == "listPets")
+    }
+
+    @Test
+    func defaultOperationIdIsNilWhenTypeHasNoOperationSuffix() {
+        let operation = OperationIdFixture.ListPets()
+
+        #expect(operation.operationId == nil)
+    }
+}
+

--- a/Tests/FeatherOpenAPITests/OperationRepresentableTestSuite.swift
+++ b/Tests/FeatherOpenAPITests/OperationRepresentableTestSuite.swift
@@ -2,7 +2,7 @@
 //  OperationRepresentableTestSuite.swift
 //  feather-openapi
 //
-//  Created by Codex on 2026. 03. 24..
+//  Created by Codex on 2026. 03. 24.
 //
 
 import OpenAPIKit30
@@ -31,7 +31,6 @@ private enum OperationIdFixture {
     }
 }
 
-
 @Suite
 struct OperationRepresentableTestSuite {
 
@@ -49,4 +48,3 @@ struct OperationRepresentableTestSuite {
         #expect(operation.operationId == nil)
     }
 }
-

--- a/Tests/FeatherOpenAPITests/PathComponentTestSuite.swift
+++ b/Tests/FeatherOpenAPITests/PathComponentTestSuite.swift
@@ -2,7 +2,7 @@
 //  PathComponentTestSuite.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 
 import Testing
 

--- a/Tests/FeatherOpenAPITests/Petstore/ApiResponse/ApiResponse+Schemas.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/ApiResponse/ApiResponse+Schemas.swift
@@ -2,7 +2,7 @@
 //  ApiResponse+Schemas.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/ApiResponse/ApiResponse.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/ApiResponse/ApiResponse.swift
@@ -2,7 +2,7 @@
 //  ApiResponse.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/Category/Category+Schemas.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/Category/Category+Schemas.swift
@@ -2,7 +2,7 @@
 //  Category+Schemas.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/Category/Category.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/Category/Category.swift
@@ -2,7 +2,7 @@
 //  Category.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/Pet/Pet+Operations.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/Pet/Pet+Operations.swift
@@ -2,7 +2,7 @@
 //  Pet+Operations.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/Pet/Pet+Parameters.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/Pet/Pet+Parameters.swift
@@ -2,7 +2,7 @@
 //  Pet+Parameters.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/Pet/Pet+PathItems.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/Pet/Pet+PathItems.swift
@@ -2,7 +2,7 @@
 //  Pet+PathItems.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/Pet/Pet+RequestBodies.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/Pet/Pet+RequestBodies.swift
@@ -2,7 +2,7 @@
 //  Pet+RequestBodies.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/Pet/Pet+Responses.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/Pet/Pet+Responses.swift
@@ -2,7 +2,7 @@
 //  Pet+Responses.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/Pet/Pet+Schemas.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/Pet/Pet+Schemas.swift
@@ -2,7 +2,7 @@
 //  Pet+Schemas.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/Pet/Pet+Tags.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/Pet/Pet+Tags.swift
@@ -2,7 +2,7 @@
 //  Pet+Tags.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/Pet/Pet.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/Pet/Pet.swift
@@ -2,7 +2,7 @@
 //  Pet.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/Petstore+Security.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/Petstore+Security.swift
@@ -2,7 +2,7 @@
 //  Petstore+Security.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/Petstore.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/Petstore.swift
@@ -2,7 +2,7 @@
 //  Petstore.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/PetstoreTestSuite.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/PetstoreTestSuite.swift
@@ -2,7 +2,7 @@
 //  PetstoreTestSuite.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import OpenAPIKit30

--- a/Tests/FeatherOpenAPITests/Petstore/Store/Store+Operations.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/Store/Store+Operations.swift
@@ -2,7 +2,7 @@
 //  Store+Operations.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/Store/Store+Parameters.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/Store/Store+Parameters.swift
@@ -2,7 +2,7 @@
 //  Store+Parameters.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/Store/Store+PathItems.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/Store/Store+PathItems.swift
@@ -2,7 +2,7 @@
 //  Store+PathItems.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/Store/Store+RequestBodies.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/Store/Store+RequestBodies.swift
@@ -2,7 +2,7 @@
 //  Store+RequestBodies.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/Store/Store+Responses.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/Store/Store+Responses.swift
@@ -2,7 +2,7 @@
 //  Store+Responses.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/Store/Store+Schemas.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/Store/Store+Schemas.swift
@@ -2,7 +2,7 @@
 //  Store+Schemas.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/Store/Store+Tags.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/Store/Store+Tags.swift
@@ -2,7 +2,7 @@
 //  Store+Tags.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/Store/Store.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/Store/Store.swift
@@ -2,7 +2,7 @@
 //  Store.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/Tag/Tag+Schemas.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/Tag/Tag+Schemas.swift
@@ -2,7 +2,7 @@
 //  Tag+Schemas.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/Tag/Tag.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/Tag/Tag.swift
@@ -2,7 +2,7 @@
 //  Tag.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/User/User+Headers.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/User/User+Headers.swift
@@ -2,7 +2,7 @@
 //  User+Headers.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/User/User+Operations.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/User/User+Operations.swift
@@ -2,7 +2,7 @@
 //  User+Operations.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/User/User+Parameters.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/User/User+Parameters.swift
@@ -2,7 +2,7 @@
 //  User+Parameters.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/User/User+PathItems.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/User/User+PathItems.swift
@@ -2,7 +2,7 @@
 //  User+PathItems.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/User/User+RequestBodies.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/User/User+RequestBodies.swift
@@ -2,7 +2,7 @@
 //  User+RequestBodies.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/User/User+Responses.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/User/User+Responses.swift
@@ -2,7 +2,7 @@
 //  User+Responses.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/User/User+Schemas.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/User/User+Schemas.swift
@@ -2,7 +2,7 @@
 //  User+Schemas.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/User/User+Tags.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/User/User+Tags.swift
@@ -2,7 +2,7 @@
 //  User+Tags.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/Petstore/User/User.swift
+++ b/Tests/FeatherOpenAPITests/Petstore/User/User.swift
@@ -2,7 +2,7 @@
 //  User.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 22..
+//  Created by Tibor Bödecs on 2026. 01. 22.
 //
 
 import FeatherOpenAPI

--- a/Tests/FeatherOpenAPITests/ResponseSerializationTestSuite.swift
+++ b/Tests/FeatherOpenAPITests/ResponseSerializationTestSuite.swift
@@ -34,7 +34,6 @@ private struct RequestIdHeader: HeaderRepresentable {
 
 private struct RequestIdSchema: StringSchemaRepresentable {}
 
-
 @Suite
 struct ResponseSerializationTestSuite {
 
@@ -65,4 +64,3 @@ struct ResponseSerializationTestSuite {
         #expect(yaml.contains("x-request-id:"))
     }
 }
-

--- a/Tests/FeatherOpenAPITests/ResponseSerializationTestSuite.swift
+++ b/Tests/FeatherOpenAPITests/ResponseSerializationTestSuite.swift
@@ -1,0 +1,68 @@
+//
+//  ResponseSerializationTestSuite.swift
+//  feather-openapi
+//
+//  Created by Codex on 2026. 03. 24.
+//
+
+import OpenAPIKit30
+import Testing
+import Yams
+
+@testable import FeatherOpenAPI
+
+private struct EmptyHeadersResponse: ResponseRepresentable {
+    let description = "Unauthorized"
+    let openAPIIdentifier = "EmptyHeadersResponse"
+    var contentMap: ContentMap { [:] }
+}
+
+private struct CustomHeaderResponse: ResponseRepresentable {
+    let description = "Ok"
+    let openAPIIdentifier = "CustomHeaderResponse"
+    var contentMap: ContentMap { [:] }
+    var headerMap: HeaderMap {
+        [
+            "x-request-id": RequestIdHeader()
+        ]
+    }
+}
+
+private struct RequestIdHeader: HeaderRepresentable {
+    var schema: any OpenAPISchemaRepresentable { RequestIdSchema() }
+}
+
+private struct RequestIdSchema: StringSchemaRepresentable {}
+
+
+@Suite
+struct ResponseSerializationTestSuite {
+
+    @Test
+    func emptyHeaderMapDoesNotSerializeHeadersField() throws {
+        let response = EmptyHeadersResponse().openAPIResponse()
+        guard case .b(let openAPIResponse) = response else {
+            Issue.record("Expected inline OpenAPI response")
+            return
+        }
+
+        let yaml = try YAMLEncoder().encode(openAPIResponse)
+
+        #expect(yaml.contains("headers:") == false)
+    }
+
+    @Test
+    func nonEmptyHeaderMapStillSerializesHeadersField() throws {
+        let response = CustomHeaderResponse().openAPIResponse()
+        guard case .b(let openAPIResponse) = response else {
+            Issue.record("Expected inline OpenAPI response")
+            return
+        }
+
+        let yaml = try YAMLEncoder().encode(openAPIResponse)
+
+        #expect(yaml.contains("headers:"))
+        #expect(yaml.contains("x-request-id:"))
+    }
+}
+

--- a/Tests/FeatherOpenAPITests/SchemaSerializationTestSuite.swift
+++ b/Tests/FeatherOpenAPITests/SchemaSerializationTestSuite.swift
@@ -1,3 +1,9 @@
+//
+//  SchemaSerializationTestSuite.swift
+//  feather-openapi
+//
+//  Created by Binary Birds on 2026. 02. 24.
+
 import OpenAPIKit30
 import Testing
 import Yams

--- a/Tests/FeatherOpenAPITests/TestObjects.swift
+++ b/Tests/FeatherOpenAPITests/TestObjects.swift
@@ -2,7 +2,7 @@
 //  TestObjects.swift
 //  feather-openapi
 //
-//  Created by Tibor Bödecs on 2026. 01. 21..
+//  Created by Tibor Bödecs on 2026. 01. 21.
 //
 
 import FeatherOpenAPI


### PR DESCRIPTION
- fixes a bug related to default operation id values
- op id defaults to the altered type name if it has `Operation` suffix
- add test coverage to check default values
- updated readme (1.0.0-beta.7)
- fix format & file headers
- avoid empty response header serialization: `headers: {}`
- tests for empty header response serialization fix